### PR TITLE
Fix/users

### DIFF
--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -131,13 +131,18 @@ userRouter.patch(
       if (!(await passwordMatch(checkPassword, userid))) {
         return res.status(400).json(response.response400(AUTH_FAIL));
       }
-      if (await getUserByUserInfo({ email: modifyDetail.email })) {
-        return res.status(409).json(response.response409(EXIST_EMAIL));
+      const dupEmail = await getUserByUserInfo({ email: modifyDetail.email });
+      const dupNickname = await getUserByUserInfo({ nickname: modifyDetail.nickname });
+      if (dupEmail) {
+        if (dupEmail.id !== userid) {
+          return res.status(409).json(response.response409(EXIST_EMAIL));
+        }
       }
-      if (await getUserByUserInfo({ nickname: modifyDetail.nickname })) {
-        return res.status(409).json(response.response409(EXIST_ID));
+      if (dupNickname) {
+        if (dupNickname.id !== userid) {
+          return res.status(409).json(response.response409(EXIST_ID));
+        }
       }
-
       if (req.file) {
         const imageDetail = {
           name: req.file.filename,

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -20,13 +20,16 @@ import {
   DELETE_USER_FAIL,
   MODIFY_USER_SUCCESS,
   MODIFY_USER_FAIL,
-  NO_USER,
   AUTH_FAIL,
   EXIST_EMAIL,
   EXIST_ID,
 } from '../../util/response/message';
 import response from '../../util/response';
 import { passwordMatch } from '../../services/auth';
+import { uploadProfile } from '../middleware/multer';
+import { postImage, deleteImage } from '../../services/image';
+import { IImageDetail } from '../../interfaces/image';
+import Image from '../../models/image';
 
 const userRouter = Router();
 
@@ -114,29 +117,41 @@ userRouter.put(
       password: Joi.string(),
       email: Joi.string(),
       introduce: Joi.string().allow('', null),
-      profile_image: Joi.number().allow('', null),
       checkpassword: Joi.string(),
     }),
   }),
+  uploadProfile,
   async (req: IJwtRequest, res: Response, next: NextFunction) => {
-    const userid = req.decoded?.id;
+    const userid: number = req.decoded?.id!;
     const checkPassword = req.body.checkpassword;
-    const { email, nickname } = req.body;
+    let modifyDetail = { id: userid, ...req.body };
+    const existUser = await getUserByUserInfo({ id: modifyDetail.id });
+
     try {
-      if (!userid) {
-        return res.status(404).json(response.response404(NO_USER));
-      }
       if (!(await passwordMatch(checkPassword, userid))) {
         return res.status(400).json(response.response400(AUTH_FAIL));
       }
-
-      if (await getUserByUserInfo({ email })) {
+      if (await getUserByUserInfo({ email: modifyDetail.email })) {
         return res.status(409).json(response.response409(EXIST_EMAIL));
       }
-      if (await getUserByUserInfo({ nickname })) {
+
+      if (await getUserByUserInfo({ nickname: modifyDetail.nickname })) {
         return res.status(409).json(response.response409(EXIST_ID));
       }
-      const user = await modifyUser(req.body as IUserModify, userid);
+
+      if (req.file) {
+        const imageDetail = {
+          name: req.file.filename,
+          type: req.file.mimetype,
+          path: req.file.path,
+        };
+        if (existUser?.profile_image!) {
+          await deleteImage(existUser?.profile_image!);
+        }
+        const newImage: Image | null = await postImage(imageDetail as IImageDetail);
+        modifyDetail = { ...modifyDetail, profile_image: newImage?.id };
+      }
+      const user = await modifyUser(modifyDetail as IUserModify);
       if (user) {
         return res.status(200).json(response.response200(MODIFY_USER_SUCCESS, user));
       }

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -108,7 +108,7 @@ userRouter.delete(
   },
 );
 
-userRouter.put(
+userRouter.patch(
   '/',
   checkJWT,
   celebrate({
@@ -134,7 +134,6 @@ userRouter.put(
       if (await getUserByUserInfo({ email: modifyDetail.email })) {
         return res.status(409).json(response.response409(EXIST_EMAIL));
       }
-
       if (await getUserByUserInfo({ nickname: modifyDetail.nickname })) {
         return res.status(409).json(response.response409(EXIST_ID));
       }
@@ -145,8 +144,8 @@ userRouter.put(
           type: req.file.mimetype,
           path: req.file.path,
         };
-        if (existUser?.profile_image!) {
-          await deleteImage(existUser?.profile_image!);
+        if (existUser?.profile_image) {
+          await deleteImage(existUser?.profile_image);
         }
         const newImage: Image | null = await postImage(imageDetail as IImageDetail);
         modifyDetail = { ...modifyDetail, profile_image: newImage?.id };

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -5,7 +5,7 @@ export interface IUserforSignUp {
 }
 
 export interface IUserInfo {
-  id?: string;
+  id?: number;
   email?: string;
   nickname?: string;
 }
@@ -16,6 +16,7 @@ export interface IUserAction {
 }
 
 export interface IUserModify {
+  id: number;
   email: string;
   nickname: string;
   password?: string;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -13,7 +13,7 @@ export default class User extends Model {
 
   public introduce!: string | null;
 
-  public profile_image!: string | null;
+  public profile_image!: number | null;
 
   public readonly created_at!: Date;
 

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -42,31 +42,25 @@ export const deleteUser = async (id: number): Promise<number> => {
   return user;
 };
 
-export const modifyUser = async (userInfo: IUserModify, id: number): Promise<User | null> => {
-  const existUser = await User.findByPk(id);
+export const modifyUser = async (userInfo: IUserModify): Promise<User | null> => {
+  const existUser = await User.findByPk(userInfo.id);
   if (!existUser) {
     return null;
   }
   const inputPassword = userInfo.password;
   if (inputPassword) {
-    if (!(await passwordMatch(inputPassword, id))) {
+    if (!(await passwordMatch(inputPassword, existUser.id))) {
       const encryptedPw = await bcrypt.hash(inputPassword, 10);
-      existUser.update(
-        {
-          password: encryptedPw,
-        },
-        { where: { id } },
-      );
+      existUser.update({
+        password: encryptedPw,
+      });
     }
   }
-  const user = existUser.update(
-    {
-      email: userInfo.email,
-      nickname: userInfo.nickname,
-      introduce: userInfo.introduce,
-      profile_image: userInfo.profile_image,
-    },
-    { where: { id } },
-  );
+  const user = existUser.update({
+    email: userInfo.email,
+    nickname: userInfo.nickname,
+    introduce: userInfo.introduce,
+    profile_image: userInfo.profile_image,
+  });
   return user;
 };

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -43,7 +43,7 @@ export const deleteUser = async (id: number): Promise<number> => {
 };
 
 export const modifyUser = async (userInfo: IUserModify): Promise<User | null> => {
-  const existUser = await User.findByPk(userInfo.id);
+  const existUser: User | null = await User.findByPk(userInfo.id);
   if (!existUser) {
     return null;
   }


### PR DESCRIPTION
<!-- 이 Pull Request에 대한 간략한 소개 -->

#### 관련 이슈 <!-- #[issue_number] --> 
#49 User modify profile image


#### 변경 사항 <!-- 변경한 내용을 목록화하여 적어주세요. --> 
 - 기존 HTTP method PUT을 PATCH로 변경하였습니다.
-> PUT은 자원의 전체 교체, PATCH는 일부 교체로 알고있습니다. 기존 코드인 PUT으로 테스트할 때 body에 안바꿀 다른 자원을 입력 안하고 회원정보를 수정하여도 포함되지 않은 자원들이 null로 변경되는 경우가 없어서 그냥 놔두었습니다. 하지만 사용법 상 PATCH가 맞는 것 같아 수정하였습니다.

 - 프로필 사진 등록
 -> req.body에 file이 있을 시, 이를 프로필 이미지로 사용합니다. 클라우드나리에 사진을 업로드하며. 이 정보를 이미지 테이블에 저장하고, 기존 이미지는 두 곳 모두에서 삭제됩니다.

#### PR Point <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
 - 이미지가 잘 등록되고, 새 이미지 등록시 기존 데이터는 저장소 및 테이블에서 잘 빠지는지 봐주세요
 - JWT 쪽 인터페이스가 ?로 되어 있어서 userid 접근시에 !가 필요한데 더 깔끔한 방법이 있을까요?
<img width="388" alt="스크린샷 2021-01-28 오후 5 45 22" src="https://user-images.githubusercontent.com/22341374/106112482-a8cb1b00-6190-11eb-8ca2-ae432acf28c9.png">


#### Reference <!-- 참고할 링크 혹은 참고 사항을 정리해둔 이슈가 있다면 적어주세요. -->
