### PR TITLE
Fix/users

### DIFF
--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -20,6 +20,7 @@ import {
   DELETE_USER_FAIL,
   MODIFY_USER_SUCCESS,
   MODIFY_USER_FAIL,
+  AUTH_SUCCESS,
   AUTH_FAIL,
   EXIST_EMAIL,
   EXIST_ID,
@@ -86,6 +87,29 @@ userRouter.get(
   },
 );
 
+userRouter.get(
+  '/check',
+  checkJWT,
+  celebrate({
+    [Segments.BODY]: Joi.object().keys({
+      checkpassword: Joi.string().required(),
+    }),
+  }),
+  async (req: IJwtRequest, res: Response, next: NextFunction) => {
+    const userid: number = req.decoded?.id!;
+    const checkPassword: string = req.body.checkpassword;
+    try {
+      if (!(await passwordMatch(checkPassword, userid))) {
+        return res.status(403).json(response.response403(AUTH_FAIL));
+      }
+      return res.status(200).json(response.response200(AUTH_SUCCESS, { success: true }));
+    } catch (err) {
+      Logger.error('🔥 error %o', err);
+      return next(err);
+    }
+  },
+);
+
 userRouter.delete(
   '/:id',
   celebrate({
@@ -111,26 +135,20 @@ userRouter.delete(
 userRouter.patch(
   '/',
   checkJWT,
+  uploadProfile,
   celebrate({
     [Segments.BODY]: Joi.object().keys({
       nickname: Joi.string(),
       password: Joi.string(),
       email: Joi.string(),
       introduce: Joi.string().allow('', null),
-      checkpassword: Joi.string(),
     }),
   }),
-  uploadProfile,
   async (req: IJwtRequest, res: Response, next: NextFunction) => {
     const userid: number = req.decoded?.id!;
-    const checkPassword = req.body.checkpassword;
     let modifyDetail = { id: userid, ...req.body };
     const existUser = await getUserByUserInfo({ id: modifyDetail.id });
-
     try {
-      if (!(await passwordMatch(checkPassword, userid))) {
-        return res.status(403).json(response.response403(AUTH_FAIL));
-      }
       const dupEmail = await getUserByUserInfo({ email: modifyDetail.email });
       const dupNickname = await getUserByUserInfo({ nickname: modifyDetail.nickname });
       if (dupEmail) {

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -129,7 +129,7 @@ userRouter.patch(
 
     try {
       if (!(await passwordMatch(checkPassword, userid))) {
-        return res.status(400).json(response.response400(AUTH_FAIL));
+        return res.status(403).json(response.response403(AUTH_FAIL));
       }
       const dupEmail = await getUserByUserInfo({ email: modifyDetail.email });
       const dupNickname = await getUserByUserInfo({ nickname: modifyDetail.nickname });

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,6 +1,7 @@
 import { Model, DataTypes } from 'sequelize';
 import bcrypt from 'bcrypt';
 import sequelize from '../config/database';
+import Image from './image';
 
 export default class User extends Model {
   public id!: number;
@@ -57,6 +58,8 @@ User.init(
     underscored: true,
   },
 );
+User.belongsTo(Image, { foreignKey: 'profile_image' });
+
 User.beforeCreate(async (user) => {
   const encryptedPw = await bcrypt.hash(user.password, 10);
   user.password = encryptedPw;

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,6 +1,7 @@
 import { Op } from 'sequelize';
 import bcrypt from 'bcrypt';
 import User from '../models/user';
+import Image from '../models/image';
 import { IUserforSignUp, IUserInfo, IUserModify } from '../interfaces/user';
 import { passwordMatch } from './auth';
 
@@ -13,7 +14,14 @@ export const createUser = async (userInfo: IUserforSignUp): Promise<void> => {
 };
 
 export const getAllUser = async (): Promise<User[] | null> => {
-  const allUser = await User.findAll({});
+  const allUser = await User.findAll({
+    include: [
+      {
+        model: Image,
+        attributes: ['id', 'path'],
+      },
+    ],
+  });
   return allUser;
 };
 
@@ -26,12 +34,28 @@ export const getUserByUserInfo = async (userInfo: IUserInfo): Promise<User | nul
         { nickname: userInfo.nickname || null },
       ],
     },
+    include: [
+      {
+        model: Image,
+        attributes: ['id', 'path'],
+      },
+    ],
   });
   return user;
 };
 
 export const getUsernameById = async (id: number): Promise<User | null> => {
-  const nickname = await User.findOne({ where: { id }, raw: true, attributes: ['nickname'] });
+  const nickname = await User.findOne({
+    where: { id },
+    raw: true,
+    attributes: ['nickname'],
+    include: [
+      {
+        model: Image,
+        attributes: ['id', 'path'],
+      },
+    ],
+  });
   return nickname;
 };
 

--- a/src/util/mix-api.ts
+++ b/src/util/mix-api.ts
@@ -1,5 +1,5 @@
 /* Server URL */
-export const SERVER_URL = 'http://bletcher-mix.herokuapp.com'; // heroku
+export const SERVER_URL = 'http://193.122.101.191:8000'; // Oracle
 // export const SERVER_URL = 'http://localhost:8000'; // local
 
 /* Mix Router */


### PR DESCRIPTION
<!-- 이 Pull Request에 대한 간략한 소개 -->

#### 관련 이슈 <!-- #[issue_number] -->
#51 PATCH /user route

#### 변경 사항 <!-- 변경한 내용을 목록화하여 적어주세요. --> 
- 프로필 이미지 업데이트 middleware : checkPassword 없이도 이미지는 변경되는 문제 처리
 : GET users/check 에서 기존 비밀번호 확인 후, 회원정보 변경으로 진행하는 것으로 해결

- checkPassword 말고도 비밀번호를 변경하고자 하는 경우에 대한 처리
 : PATCH 요청 BODY에 'password' 값을 통해 변경 (값이 들어오면 bcrypt 처리 후 정보 저장)

- checkPassword 에러 코드 바꾸기
 : 403으로 변경하였습니다! (401 : 토큰 없는 경우, 403: 토큰 있지만 체크 패스워드 다른 경우, modify에서 409 : 중복 이메일/닉네임)

- user 정보의 profile_image 필드를 어떻게 넘겨주는지 확인하고 이슈 해결
 : 이 부분은 User 테이블과 Image 테이블을 조인하고 getUser()에 대해 조인 값을 추가하여 해결하였습니다.
<img width="889" alt="스크린샷 2021-02-27 오후 5 43 26" src="https://user-images.githubusercontent.com/22341374/109382363-544bc480-7923-11eb-837f-70920f9ca678.png">


#### PR Point <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
 : 회원 정보 수정과 관련하여 더 필요하거나 빠진 부분이 있는지 말해주세요! 테스트하고 버그 있는지도!

아 그리구 프사를 지우는 경우(카톡 기본 이미지처럼)는 어떻게 해야할까요? 의견 부탁드립니다.


#### Reference <!-- 참고할 링크 혹은 참고 사항을 정리해둔 이슈가 있다면 적어주세요. -->
